### PR TITLE
Fix(core): Use full model name for Gemini API

### DIFF
--- a/core/intent_detector.py
+++ b/core/intent_detector.py
@@ -6,7 +6,7 @@ import json
 try:
     genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
     # Initialize the generative model
-    model = genai.GenerativeModel('gemini-pro')
+    model = genai.GenerativeModel('models/gemini-pro')
 except Exception as e:
     print(f"Error configuring Gemini API: {e}")
     model = None


### PR DESCRIPTION
The `genai.GenerativeModel` constructor requires the full model name, including the `models/` prefix, for the version of the API used in this project.

Using the short name 'gemini-pro' resulted in a `404 Not Found` error during intent detection.

This change updates the model name to 'models/gemini-pro' to resolve the connection issue with the Gemini API.